### PR TITLE
Remove unnecessary const qualifier

### DIFF
--- a/include/VDTK/VolumeDataHandler.h
+++ b/include/VDTK/VolumeDataHandler.h
@@ -29,7 +29,7 @@ public:
     bool exportToBitmapMonochrom(const std::filesystem::path& directoryPath) const;
 
     // gets the raw voxel value from the curren volume on a given position
-    const uint16_t getRawValue(const std::size_t x, const std::size_t y, const std::size_t z) const;
+    uint16_t getRawValue(const std::size_t x, const std::size_t y, const std::size_t z) const;
     const VolumeData getVolumeData() const;
 
     void applyWindow(const int32_t windowLevel, const int32_t windowWidth,
@@ -42,7 +42,7 @@ public:
     // threshold between 0 and UINT16_MAX
     void cutBorders(const uint16_t thresholdISO);
 
-    const void invertVoxelData();
+    void invertVoxelData();
 
     // scales volume to the choosen size
     void scaleToSize(const ScaleMode scaleMode, const VolumeSize& size);
@@ -62,7 +62,7 @@ public:
 
     void convertEndianness();
 
-    static const void printLegalNotice();
+    static void printLegalNotice();
 
 private:
     // voxel data is stored here

--- a/include/VDTK/common/CommonDataTypes.h
+++ b/include/VDTK/common/CommonDataTypes.h
@@ -30,13 +30,13 @@ public:
         m_X = m_Y = m_Z = x;
     }
 
-    const T getX() const {
+    T getX() const {
         return m_X;
     }
-    const T getY() const {
+    T getY() const {
         return m_Y;
     }
-    const T getZ() const {
+    T getZ() const {
         return m_Z;
     }
 
@@ -140,11 +140,11 @@ public:
 
         return *this;
     }
-    const bool operator==(const Vector3D& rhs) const {
+    bool operator==(const Vector3D& rhs) const {
 
         return this->m_X == rhs.m_X && this->m_Y == rhs.m_Y && this->m_Z == rhs.m_Z;
     }
-    const bool operator!=(const Vector3D& rhs) const {
+    bool operator!=(const Vector3D& rhs) const {
 
         return this->m_X != rhs.m_X || this->m_Y != rhs.m_Y || this->m_Z != rhs.m_Z;
     }
@@ -169,17 +169,17 @@ public:
                 const std::size_t width, const std::size_t height)
         : m_axis(axis), m_width(width), m_height(height), m_pixelData(pixelData) {}
 
-    const std::size_t getWidth() const {
+    std::size_t getWidth() const {
         return m_width;
     }
-    const std::size_t getHeigth() const {
+    std::size_t getHeigth() const {
         return m_height;
     }
-    const VolumeAxis getAxis() const {
+    VolumeAxis getAxis() const {
         return m_axis;
     }
 
-    const uint16_t getPixel(const std::size_t x, const std::size_t y) const {
+    uint16_t getPixel(const std::size_t x, const std::size_t y) const {
         // check if position is within slice size
         assert(x < getWidth() && y < getHeigth());
         return m_pixelData[y + (m_height * x)];
@@ -226,7 +226,7 @@ public:
     const VDTK::VolumeSpacing getSpacing() const {
         return m_Spacing;
     }
-    const uint64_t getVoxelCount() const {
+    uint64_t getVoxelCount() const {
         return m_VoxelCount;
     }
 
@@ -248,19 +248,18 @@ public:
         setVoxelValue(static_cast<std::size_t>(x), static_cast<std::size_t>(y),
                       static_cast<std::size_t>(z), static_cast<uint16_t>(value));
     }
-    const uint16_t getVoxelValue(const std::size_t x, const std::size_t y,
-                                 const std::size_t z) const {
+    uint16_t getVoxelValue(const std::size_t x, const std::size_t y, const std::size_t z) const {
         assert(x < m_Size.getX() && y < m_Size.getY() && z < m_Size.getZ());
 
         // data is stored in zyx order
         return m_Data[x + m_Size.getX() * (y + (m_Size.getY() * z))];
     }
-    const float getVoxelValue(const float x, const float y, const float z) const {
+    float getVoxelValue(const float x, const float y, const float z) const {
         assert(x >= 0.0f && y >= 0.0f && z >= 0.0f);
         return static_cast<float>(getVoxelValue(
             static_cast<std::size_t>(x), static_cast<std::size_t>(y), static_cast<std::size_t>(z)));
     }
-    const double getVoxelValue(const double x, const double y, const double z) const {
+    double getVoxelValue(const double x, const double y, const double z) const {
         assert(x >= 0.0 && y >= 0.0 && z >= 0.0);
         return static_cast<double>(getVoxelValue(
             static_cast<std::size_t>(x), static_cast<std::size_t>(y), static_cast<std::size_t>(z)));
@@ -448,7 +447,7 @@ public:
         return filterGrid;
     }
 
-    const std::size_t getKernelSize() const {
+    std::size_t getKernelSize() const {
         return kernelSize;
     }
 

--- a/include/VDTK/common/CommonIO.h
+++ b/include/VDTK/common/CommonIO.h
@@ -9,7 +9,7 @@
 namespace VDTK::FileIOCommon {
 // needed generating file names (bitmap or dicom for example)
 // could be more optimized with a look up table
-static const std::size_t numberOfDigits(std::size_t number) {
+static std::size_t numberOfDigits(std::size_t number) {
     std::size_t digits = 0;
     if (!number) {
         digits++; // to write a zero one digit is still needed
@@ -22,7 +22,7 @@ static const std::size_t numberOfDigits(std::size_t number) {
 }
 
 // checks if a character in a string is a digit
-static const bool isADigit(const std::string& s, const std::size_t index) {
+static bool isADigit(const std::string& s, const std::size_t index) {
     if (index >= s.size()) {
         return false;
     }
@@ -33,9 +33,9 @@ static const bool isADigit(const std::string& s, const std::size_t index) {
     return false;
 }
 
-static const void renameIndexedFilesInDirectory(const std::filesystem::path& directoryPath,
-                                                const std::string& sliceName = "_IMG",
-                                                const std::string& fileExtension = {}) {
+static void renameIndexedFilesInDirectory(const std::filesystem::path& directoryPath,
+                                          const std::string& sliceName = "_IMG",
+                                          const std::string& fileExtension = {}) {
     std::vector<std::filesystem::path> filePaths;
     // get all file names in directory
     for (const auto& directoryEntry : std::filesystem::directory_iterator(directoryPath)) {

--- a/src/VolumeDataHandler.cpp
+++ b/src/VolumeDataHandler.cpp
@@ -61,8 +61,8 @@ bool VolumeDataHandler::exportToBitmapMonochrom(const std::filesystem::path& dir
     return BitmapExporter::writeMonochrom(directoryPath, m_VolumeData);
 }
 
-const uint16_t VolumeDataHandler::getRawValue(const std::size_t x, const std::size_t y,
-                                              const std::size_t z) const {
+uint16_t VolumeDataHandler::getRawValue(const std::size_t x, const std::size_t y,
+                                        const std::size_t z) const {
     return m_VolumeData.getVoxelValue(x, y, z);
 }
 
@@ -90,7 +90,7 @@ void VolumeDataHandler::cutBorders(const uint16_t thresholdISO) {
     EdgeCutter::cutBorders(&m_VolumeData, thresholdISO);
 }
 
-const void VolumeDataHandler::invertVoxelData() {
+void VolumeDataHandler::invertVoxelData() {
     InvertVoxelFilter::invertVoxelData(m_VolumeData);
 }
 
@@ -148,7 +148,7 @@ void VolumeDataHandler::convertEndianness() {
     EndianConverter::flipEndianness(&m_VolumeData);
 }
 
-const void VolumeDataHandler::printLegalNotice() {
+void VolumeDataHandler::printLegalNotice() {
     // Very ugly, but does the job.
     // Feel free to make it better :-)
 

--- a/src/file_io/binary_slice/BinarySliceImporter.cpp
+++ b/src/file_io/binary_slice/BinarySliceImporter.cpp
@@ -7,11 +7,10 @@ BinarySliceImporter::BinarySliceImporter() {}
 
 BinarySliceImporter::~BinarySliceImporter() {}
 
-const bool BinarySliceImporter::import(VolumeData* const volumeData,
-                                       const std::filesystem::path& directoryPath,
-                                       const uint8_t bitsPerVoxel, const VolumeAxis axis,
-                                       const VDTK::VolumeSize size,
-                                       const VDTK::VolumeSpacing spacing) {
+bool BinarySliceImporter::import(VolumeData* const volumeData,
+                                 const std::filesystem::path& directoryPath,
+                                 const uint8_t bitsPerVoxel, const VolumeAxis axis,
+                                 const VDTK::VolumeSize size, const VDTK::VolumeSpacing spacing) {
     if (!std::filesystem::exists(directoryPath)) {
         // Directory does not exist
         return false;
@@ -59,10 +58,10 @@ const bool BinarySliceImporter::import(VolumeData* const volumeData,
     return true;
 }
 
-const bool BinarySliceImporter::loadSlice(VolumeSlice* const volumeSlice,
-                                          const std::filesystem::path& filePath,
-                                          const uint8_t bitsPerVoxel, const VolumeAxis axis,
-                                          const std::size_t width, const std::size_t height) {
+bool BinarySliceImporter::loadSlice(VolumeSlice* const volumeSlice,
+                                    const std::filesystem::path& filePath,
+                                    const uint8_t bitsPerVoxel, const VolumeAxis axis,
+                                    const std::size_t width, const std::size_t height) {
     std::size_t fileSize = 0;
     try {
         fileSize = std::filesystem::file_size(filePath);

--- a/src/file_io/binary_slice/BinarySliceImporter.h
+++ b/src/file_io/binary_slice/BinarySliceImporter.h
@@ -8,16 +8,14 @@ public:
     BinarySliceImporter();
     ~BinarySliceImporter();
 
-    static const bool import(VolumeData* const volumeData,
-                             const std::filesystem::path& directoryPath, const uint8_t bitsPerVoxel,
-                             const VolumeAxis axis, const VDTK::VolumeSize size,
-                             const VDTK::VolumeSpacing spacing);
+    static bool import(VolumeData* const volumeData, const std::filesystem::path& directoryPath,
+                       const uint8_t bitsPerVoxel, const VolumeAxis axis,
+                       const VDTK::VolumeSize size, const VDTK::VolumeSpacing spacing);
 
 private:
-    static const bool loadSlice(VolumeSlice* const volumeSlice,
-                                const std::filesystem::path& filePath, const uint8_t bitsPerVoxel,
-                                const VolumeAxis axis, const std::size_t width,
-                                const std::size_t height);
+    static bool loadSlice(VolumeSlice* const volumeSlice, const std::filesystem::path& filePath,
+                          const uint8_t bitsPerVoxel, const VolumeAxis axis,
+                          const std::size_t width, const std::size_t height);
     static const std::vector<uint16_t> convertTo16Bit(std::vector<char>* buffer,
                                                       const uint8_t bitsPerPixel,
                                                       const uint64_t pixelCount);

--- a/src/file_io/bitmap/BitmapExporter.cpp
+++ b/src/file_io/bitmap/BitmapExporter.cpp
@@ -8,8 +8,8 @@
 #include "BitmapExporter.h"
 
 namespace VDTK {
-const bool BitmapExporter::writeColor(const std::filesystem::path& directoryPath,
-                                      const VolumeData& volume) {
+bool BitmapExporter::writeColor(const std::filesystem::path& directoryPath,
+                                const VolumeData& volume) {
     writeAxis(directoryPath, volume, VolumeAxis::YZAxis, PixelMode::RGBColor);
     writeAxis(directoryPath, volume, VolumeAxis::XZAxis, PixelMode::RGBColor);
     writeAxis(directoryPath, volume, VolumeAxis::XYAxis, PixelMode::RGBColor);
@@ -18,8 +18,8 @@ const bool BitmapExporter::writeColor(const std::filesystem::path& directoryPath
     return true;
 }
 
-const bool BitmapExporter::writeMonochrom(const std::filesystem::path& directoryPath,
-                                          const VolumeData& volume) {
+bool BitmapExporter::writeMonochrom(const std::filesystem::path& directoryPath,
+                                    const VolumeData& volume) {
     writeAxis(directoryPath, volume, VolumeAxis::YZAxis, PixelMode::RGBMonochrom);
     writeAxis(directoryPath, volume, VolumeAxis::XZAxis, PixelMode::RGBMonochrom);
     writeAxis(directoryPath, volume, VolumeAxis::XYAxis, PixelMode::RGBMonochrom);
@@ -55,9 +55,8 @@ inline const std::vector<char> BitmapExporter::convertToRGBMonochrom(const uint1
     return pixel;
 }
 
-const void BitmapExporter::writeAxis(const std::filesystem::path& directoryPath,
-                                     const VolumeData& volume, VolumeAxis axis,
-                                     const PixelMode pixelMode) {
+void BitmapExporter::writeAxis(const std::filesystem::path& directoryPath, const VolumeData& volume,
+                               VolumeAxis axis, const PixelMode pixelMode) {
     // Function pointer for the selected pixel mode
     const std::vector<char> (*convertToPixel)(uint16_t) = nullptr;
     switch (pixelMode) {
@@ -98,10 +97,10 @@ const void BitmapExporter::writeAxis(const std::filesystem::path& directoryPath,
     }
 }
 
-const void BitmapExporter::writeAxisAtIndex(const std::vector<char> (*convertToPixel)(uint16_t),
-                                            const std::filesystem::path& directoryPath,
-                                            const VolumeData& volume, VolumeAxis axis,
-                                            const std::size_t sliceIndex) {
+void BitmapExporter::writeAxisAtIndex(const std::vector<char> (*convertToPixel)(uint16_t),
+                                      const std::filesystem::path& directoryPath,
+                                      const VolumeData& volume, VolumeAxis axis,
+                                      const std::size_t sliceIndex) {
     std::string fileName = {};
 
     // TODO: move to own function

--- a/src/file_io/bitmap/BitmapExporter.h
+++ b/src/file_io/bitmap/BitmapExporter.h
@@ -4,10 +4,9 @@
 namespace VDTK {
 class BitmapExporter {
 public:
-    static const bool writeColor(const std::filesystem::path& directoryPath,
-                                 const VolumeData& volume);
-    static const bool writeMonochrom(const std::filesystem::path& directoryPath,
-                                     const VolumeData& volume);
+    static bool writeColor(const std::filesystem::path& directoryPath, const VolumeData& volume);
+    static bool writeMonochrom(const std::filesystem::path& directoryPath,
+                               const VolumeData& volume);
 
 private:
     enum class PixelMode { RGBColor, RGBMonochrom };
@@ -18,12 +17,11 @@ private:
     // RBG channel)
     static inline const std::vector<char> convertToRGBMonochrom(const uint16_t voxelValue);
 
-    static const void writeAxis(const std::filesystem::path& directoryPath,
-                                const VolumeData& volume, VolumeAxis axis,
-                                const PixelMode pixelMode);
-    static const void writeAxisAtIndex(const std::vector<char> (*convertToPixel)(uint16_t),
-                                       const std::filesystem::path& directoryPath,
-                                       const VolumeData& volume, VolumeAxis axis,
-                                       const std::size_t sliceIndex);
+    static void writeAxis(const std::filesystem::path& directoryPath, const VolumeData& volume,
+                          VolumeAxis axis, const PixelMode pixelMode);
+    static void writeAxisAtIndex(const std::vector<char> (*convertToPixel)(uint16_t),
+                                 const std::filesystem::path& directoryPath,
+                                 const VolumeData& volume, VolumeAxis axis,
+                                 const std::size_t sliceIndex);
 };
 } // namespace VDTK

--- a/src/file_io/bitmap/BitmapImporter.cpp
+++ b/src/file_io/bitmap/BitmapImporter.cpp
@@ -21,20 +21,19 @@ BitmapImporter::BitmapImporter() {}
 
 BitmapImporter::~BitmapImporter() {}
 
-const bool BitmapImporter::importMonochrom(VolumeData* const volumeData,
-                                           const std::filesystem::path& directoryPath,
-                                           const VolumeAxis axis,
-                                           const VDTK::VolumeSpacing spacing) {
+bool BitmapImporter::importMonochrom(VolumeData* const volumeData,
+                                     const std::filesystem::path& directoryPath,
+                                     const VolumeAxis axis, const VDTK::VolumeSpacing spacing) {
     return import(volumeData, directoryPath, axis, spacing, PixelMode::RGBMonochrom);
 }
 
-const bool BitmapImporter::importColor(VolumeData* const volumeData,
-                                       const std::filesystem::path& directoryPath,
-                                       const VolumeAxis axis, const VDTK::VolumeSpacing spacing) {
+bool BitmapImporter::importColor(VolumeData* const volumeData,
+                                 const std::filesystem::path& directoryPath, const VolumeAxis axis,
+                                 const VDTK::VolumeSpacing spacing) {
     return import(volumeData, directoryPath, axis, spacing, PixelMode::RGBColor);
 }
 
-inline const uint16_t BitmapImporter::pixelRGBColorToVoxel(const std::vector<char> pixel) {
+inline uint16_t BitmapImporter::pixelRGBColorToVoxel(const std::vector<char> pixel) {
     // convert pixel to unsigned int (technically 32 bit, but interpreted as 24
     // bit)
     std::vector<char> rawPixel24Bit(4);
@@ -52,7 +51,7 @@ inline const uint16_t BitmapImporter::pixelRGBColorToVoxel(const std::vector<cha
     return static_cast<uint16_t>(pixel24Bit);
 }
 
-inline const uint16_t BitmapImporter::pixelRGBMonochromToVoxel(const std::vector<char> pixel) {
+inline uint16_t BitmapImporter::pixelRGBMonochromToVoxel(const std::vector<char> pixel) {
     // calculate averange of 3 8-bit channels (RGB)
     uint32_t rawPixel = 0;
     rawPixel += static_cast<uint32_t>(pixel[0]);
@@ -66,7 +65,7 @@ inline const uint16_t BitmapImporter::pixelRGBMonochromToVoxel(const std::vector
     return static_cast<uint16_t>(rawPixel);
 }
 
-const std::size_t BitmapImporter::getNumberOfBitmapsInDirectory(
+std::size_t BitmapImporter::getNumberOfBitmapsInDirectory(
     const std::filesystem::path& directoryPath) {
     std::size_t numberOfBitmaps = 0;
     for (const auto& directoryEntry : std::filesystem::directory_iterator(directoryPath)) {
@@ -133,9 +132,9 @@ const VDTK::VolumeSize BitmapImporter::calculateVolumeSize(
 }
 
 // TODO: needs some refactoring
-const bool BitmapImporter::import(VolumeData* const volumeData,
-                                  const std::filesystem::path& directoryPath, const VolumeAxis axis,
-                                  const VDTK::VolumeSpacing spacing, const PixelMode pixelMode) {
+bool BitmapImporter::import(VolumeData* const volumeData,
+                            const std::filesystem::path& directoryPath, const VolumeAxis axis,
+                            const VDTK::VolumeSpacing spacing, const PixelMode pixelMode) {
     if (!std::filesystem::exists(directoryPath)) {
         // Directory does not exist
         return false;

--- a/src/file_io/bitmap/BitmapImporter.h
+++ b/src/file_io/bitmap/BitmapImporter.h
@@ -7,29 +7,28 @@ public:
     BitmapImporter();
     ~BitmapImporter();
 
-    static const bool importMonochrom(VolumeData* const volumeData,
-                                      const std::filesystem::path& directoryPath,
-                                      const VolumeAxis axis, const VDTK::VolumeSpacing spacing);
-    static const bool importColor(VolumeData* const volumeData,
-                                  const std::filesystem::path& directoryPath, const VolumeAxis axis,
-                                  const VDTK::VolumeSpacing spacing);
+    static bool importMonochrom(VolumeData* const volumeData,
+                                const std::filesystem::path& directoryPath, const VolumeAxis axis,
+                                const VDTK::VolumeSpacing spacing);
+    static bool importColor(VolumeData* const volumeData,
+                            const std::filesystem::path& directoryPath, const VolumeAxis axis,
+                            const VDTK::VolumeSpacing spacing);
 
 private:
     enum class PixelMode { RGBColor, RGBMonochrom };
 
     // POSSIBLE INFORMATION LOSS (24 bit RGB pixel to 16 bit voxel value)
-    static inline const uint16_t pixelRGBColorToVoxel(const std::vector<char> pixel);
+    static inline uint16_t pixelRGBColorToVoxel(const std::vector<char> pixel);
     // if bitmap is monochrom pixel only got 8 bit. Gets converted to 16 bit voxel
     // value
-    static inline const uint16_t pixelRGBMonochromToVoxel(const std::vector<char> pixel);
+    static inline uint16_t pixelRGBMonochromToVoxel(const std::vector<char> pixel);
 
-    static const std::size_t getNumberOfBitmapsInDirectory(
-        const std::filesystem::path& directoryPath);
+    static std::size_t getNumberOfBitmapsInDirectory(const std::filesystem::path& directoryPath);
     static const VDTK::VolumeSize calculateVolumeSize(const std::filesystem::path& directoryPath,
                                                       const VolumeAxis axis);
-    static const bool import(VolumeData* const volumeData,
-                             const std::filesystem::path& directoryPath, const VolumeAxis axis,
-                             const VDTK::VolumeSpacing spacing, const PixelMode pixelMode);
+    static bool import(VolumeData* const volumeData, const std::filesystem::path& directoryPath,
+                       const VolumeAxis axis, const VDTK::VolumeSpacing spacing,
+                       const PixelMode pixelMode);
 
     static const std::vector<std::string> m_validExtenions;
 };

--- a/src/file_io/endian_conversion/EndianConverter.h
+++ b/src/file_io/endian_conversion/EndianConverter.h
@@ -7,7 +7,7 @@ public:
     EndianConverter();
     ~EndianConverter();
 
-    static const void flipEndianness(VolumeData* const volume) {
+    static void flipEndianness(VolumeData* const volume) {
         for (std::size_t x = 0; x < volume->getSize().getX(); x++) {
             for (std::size_t y = 0; y < volume->getSize().getY(); y++) {
                 for (std::size_t z = 0; z < volume->getSize().getZ(); z++) {

--- a/src/file_io/raw/RawReader.cpp
+++ b/src/file_io/raw/RawReader.cpp
@@ -59,9 +59,8 @@ const std::vector<uint16_t> RawReader::convertTo16Bit(std::vector<char>& data,
 
     switch (bitsPerVoxel) {
     case 8: {
-        std::transform(
-            data.begin(), data.end(), convertedData.begin(),
-            [](char in) -> const uint16_t { return static_cast<uint16_t>(in) * UINT8_MAX; });
+        std::transform(data.begin(), data.end(), convertedData.begin(),
+                       [](char in) -> uint16_t { return static_cast<uint16_t>(in) * UINT8_MAX; });
         break;
     }
     case 16: {

--- a/src/file_io/raw/RawWriter.cpp
+++ b/src/file_io/raw/RawWriter.cpp
@@ -19,8 +19,8 @@ const std::vector<uint8_t> RawWriter::convertTo8Bit(const std::vector<uint16_t>&
     return convertedData;
 }
 
-const bool RawWriter::write(const std::filesystem::path& filePath, const uint8_t bitsPerVoxel,
-                            const VolumeData& volume) {
+bool RawWriter::write(const std::filesystem::path& filePath, const uint8_t bitsPerVoxel,
+                      const VolumeData& volume) {
     std::ofstream file = std::ofstream(filePath, std::ios::out | std::ios::binary);
 
     if (file.fail()) {

--- a/src/file_io/raw/RawWriter.h
+++ b/src/file_io/raw/RawWriter.h
@@ -7,8 +7,8 @@ public:
     RawWriter();
     ~RawWriter();
 
-    static const bool write(const std::filesystem::path& filePath, const uint8_t bitsPerVoxel,
-                            const VolumeData& volume);
+    static bool write(const std::filesystem::path& filePath, const uint8_t bitsPerVoxel,
+                      const VolumeData& volume);
 
 private:
     static const std::vector<uint8_t> convertTo8Bit(const std::vector<uint16_t>& data,

--- a/src/filter/GridFilter.cpp
+++ b/src/filter/GridFilter.cpp
@@ -40,7 +40,7 @@ void GridFilter::applyFilterToSliceX(const VolumeData* const volume,
     }
 }
 
-const uint16_t GridFilter::filterGridAverage(
+uint16_t GridFilter::filterGridAverage(
     const std::vector<std::vector<std::vector<double>>>& filterGridValues) {
     double average = 0;
 
@@ -61,9 +61,9 @@ const uint16_t GridFilter::filterGridAverage(
     }
 }
 
-const uint16_t GridFilter::getNewVoxelValue(const VolumeData* const volume, const std::size_t x,
-                                            const std::size_t y, const std::size_t z,
-                                            const VDTK::FilterKernel& filter) {
+uint16_t GridFilter::getNewVoxelValue(const VolumeData* const volume, const std::size_t x,
+                                      const std::size_t y, const std::size_t z,
+                                      const VDTK::FilterKernel& filter) {
     // stores values of filter grid when applied to volume data
     std::vector<std::vector<std::vector<double>>> filterGridValues(
         filter.getKernelSize(),

--- a/src/filter/GridFilter.h
+++ b/src/filter/GridFilter.h
@@ -14,10 +14,10 @@ private:
     static void applyFilterToSliceX(const VolumeData* const volume,
                                     VolumeData* const filteredVolume,
                                     const VDTK::FilterKernel& filter, const std::size_t positionX);
-    static const uint16_t filterGridAverage(
+    static uint16_t filterGridAverage(
         const std::vector<std::vector<std::vector<double>>>& filterGridValues);
-    static const uint16_t getNewVoxelValue(const VolumeData* const volume, const std::size_t x,
-                                           const std::size_t y, const std::size_t z,
-                                           const VDTK::FilterKernel& filter);
+    static uint16_t getNewVoxelValue(const VolumeData* const volume, const std::size_t x,
+                                     const std::size_t y, const std::size_t z,
+                                     const VDTK::FilterKernel& filter);
 };
 } // namespace VDTK

--- a/src/filter/InvertVoxelsFilter.cpp
+++ b/src/filter/InvertVoxelsFilter.cpp
@@ -7,7 +7,7 @@ InvertVoxelFilter::InvertVoxelFilter() {}
 
 InvertVoxelFilter::~InvertVoxelFilter() {}
 
-const void InvertVoxelFilter::invertVoxelData(VolumeData& volume) {
+void InvertVoxelFilter::invertVoxelData(VolumeData& volume) {
     for (std::size_t x = 0; x < volume.getSize().getX(); x++) {
         for (std::size_t y = 0; y < volume.getSize().getY(); y++) {
             for (std::size_t z = 0; z < volume.getSize().getZ(); z++) {

--- a/src/filter/InvertVoxelsFilter.h
+++ b/src/filter/InvertVoxelsFilter.h
@@ -7,7 +7,7 @@ public:
     InvertVoxelFilter();
     ~InvertVoxelFilter();
 
-    static const void invertVoxelData(VolumeData& volume);
+    static void invertVoxelData(VolumeData& volume);
 
 private:
 };

--- a/src/filter/VolumeResizer.cpp
+++ b/src/filter/VolumeResizer.cpp
@@ -9,10 +9,10 @@ VolumeResizer::VolumeResizer() {}
 
 VolumeResizer::~VolumeResizer() {}
 
-const void VolumeResizer::scaleSliceX(const VolumeData* const volume, VolumeData* volumeScaled,
-                                      const VDTK::Vector3D<float> scale,
-                                      const InterpolationMode interpolationMode,
-                                      const float scaledPositionX) {
+void VolumeResizer::scaleSliceX(const VolumeData* const volume, VolumeData* volumeScaled,
+                                const VDTK::Vector3D<float> scale,
+                                const InterpolationMode interpolationMode,
+                                const float scaledPositionX) {
     const float originalSizeX = static_cast<float>(volume->getSize().getX());
     const float originalSizeY = static_cast<float>(volume->getSize().getY());
     const float originalSizeZ = static_cast<float>(volume->getSize().getZ());
@@ -54,9 +54,9 @@ const void VolumeResizer::scaleSliceX(const VolumeData* const volume, VolumeData
     }
 }
 
-const void VolumeResizer::scaleVolume(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
-                                      const InterpolationMode interpolationMode,
-                                      const std::size_t numberOfThreads) {
+void VolumeResizer::scaleVolume(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
+                                const InterpolationMode interpolationMode,
+                                const std::size_t numberOfThreads) {
     const float originalSizeX = static_cast<float>(volume->getSize().getX());
     const float originalSizeY = static_cast<float>(volume->getSize().getY());
     const float originalSizeZ = static_cast<float>(volume->getSize().getZ());
@@ -93,21 +93,19 @@ const void VolumeResizer::scaleVolume(VolumeData* const volume, const VDTK::Vect
     *volume = volumeScaled;
 }
 
-const void VolumeResizer::scaleNearestNeighbor(VolumeData* const volume,
-                                               const VDTK::Vector3D<float>& scale,
-                                               const std::size_t numberOfThreads) {
+void VolumeResizer::scaleNearestNeighbor(VolumeData* const volume,
+                                         const VDTK::Vector3D<float>& scale,
+                                         const std::size_t numberOfThreads) {
     scaleVolume(volume, scale, InterpolationMode::Nearest, numberOfThreads);
 }
 
-const void VolumeResizer::scaleTrilinear(VolumeData* const volume,
-                                         const VDTK::Vector3D<float>& scale,
-                                         const std::size_t numberOfThreads) {
+void VolumeResizer::scaleTrilinear(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
+                                   const std::size_t numberOfThreads) {
     scaleVolume(volume, scale, InterpolationMode::Trilinear, numberOfThreads);
 }
 
-const void VolumeResizer::scaleTricubic(VolumeData* const volume,
-                                        const VDTK::Vector3D<float>& scale,
-                                        const std::size_t numberOfThreads) {
+void VolumeResizer::scaleTricubic(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
+                                  const std::size_t numberOfThreads) {
     scaleVolume(volume, scale, InterpolationMode::Tricubic, numberOfThreads);
 }
 
@@ -129,26 +127,25 @@ const void VolumeResizer::scaleTricubic(VolumeData* const volume,
 p(x,y,z) is inside of this cube
 -------------------------------------------------*/
 
-const float VolumeResizer::getNearestNeigborValue(const VolumeData* const volume,
-                                                  const VDTK::Vector3D<float>& originalPosition) {
+float VolumeResizer::getNearestNeigborValue(const VolumeData* const volume,
+                                            const VDTK::Vector3D<float>& originalPosition) {
     return volume->getVoxelValue(std::round(originalPosition.getX()),
                                  std::round(originalPosition.getY()),
                                  std::round(originalPosition.getZ()));
 }
 
-const inline float VolumeResizer::interpolateLinear(const std::array<float, 2>& values,
-                                                    const float x) {
+inline float VolumeResizer::interpolateLinear(const std::array<float, 2>& values, const float x) {
     return values[0] * (1.0f - x) + values[1] * x;
 }
 
-const inline float VolumeResizer::interpolateBilinear(
+inline float VolumeResizer::interpolateBilinear(
     const std::array<std::array<float, 2>, 2>& valuePlane, const float x, const float y) {
     const std::array<float, 2> values = {interpolateLinear(valuePlane[0], y),
                                          interpolateLinear(valuePlane[1], y)};
     return interpolateLinear(values, x);
 }
 
-const inline float VolumeResizer::interpolateTrilinear(
+inline float VolumeResizer::interpolateTrilinear(
     const std::array<std::array<std::array<float, 2>, 2>, 2>& valueGrid, const float x,
     const float y, const float z) {
     const std::array<float, 2> values = {interpolateBilinear(valueGrid[0], y, z),
@@ -156,9 +153,9 @@ const inline float VolumeResizer::interpolateTrilinear(
     return interpolateLinear(values, x);
 }
 
-const float VolumeResizer::getTrilinearInterpolatedValue(
-    const VolumeData* const volume, const VDTK::Vector3D<float>& originalSize,
-    const VDTK::Vector3D<float>& originalPosition) {
+float VolumeResizer::getTrilinearInterpolatedValue(const VolumeData* const volume,
+                                                   const VDTK::Vector3D<float>& originalSize,
+                                                   const VDTK::Vector3D<float>& originalPosition) {
     const float x0 = std::floor(originalPosition.getX());
     const float y0 = std::floor(originalPosition.getY());
     const float z0 = std::floor(originalPosition.getZ());
@@ -187,8 +184,7 @@ const float VolumeResizer::getTrilinearInterpolatedValue(
                                 originalPosition.getY() - y0, originalPosition.getZ() - z0);
 }
 
-inline const float VolumeResizer::interpolateCubic(const std::array<float, 4>& values,
-                                                   const float x) {
+inline float VolumeResizer::interpolateCubic(const std::array<float, 4>& values, const float x) {
     return values[1] +
            0.5f * x *
                (values[2] - values[0] +
@@ -196,7 +192,7 @@ inline const float VolumeResizer::interpolateCubic(const std::array<float, 4>& v
                      x * (3.0f * (values[1] - values[2]) + values[3] - values[0])));
 }
 
-inline const float VolumeResizer::interpolateBicubic(
+inline float VolumeResizer::interpolateBicubic(
     const std::array<std::array<float, 4>, 4>& valuePlane, const float x, const float y) {
     const std::array<float, 4> values = {
         interpolateCubic(valuePlane[0], y), interpolateCubic(valuePlane[1], y),
@@ -204,7 +200,7 @@ inline const float VolumeResizer::interpolateBicubic(
     return interpolateCubic(values, x);
 }
 
-inline const float VolumeResizer::interpolateTricubic(
+inline float VolumeResizer::interpolateTricubic(
     const std::array<std::array<std::array<float, 4>, 4>, 4>& valueGrid, const float x,
     const float y, const float z) {
     const std::array<float, 4> values = {
@@ -213,9 +209,9 @@ inline const float VolumeResizer::interpolateTricubic(
     return interpolateCubic(values, x);
 }
 
-const float VolumeResizer::getTricubicInterpolatedValue(
-    const VolumeData* const volume, const VDTK::Vector3D<float>& originalSize,
-    const VDTK::Vector3D<float>& originalPosition) {
+float VolumeResizer::getTricubicInterpolatedValue(const VolumeData* const volume,
+                                                  const VDTK::Vector3D<float>& originalSize,
+                                                  const VDTK::Vector3D<float>& originalPosition) {
     const float x0 = std::floor(originalPosition.getX());
     const float y0 = std::floor(originalPosition.getY());
     const float z0 = std::floor(originalPosition.getZ());

--- a/src/filter/VolumeResizer.h
+++ b/src/filter/VolumeResizer.h
@@ -9,51 +9,49 @@ public:
     VolumeResizer();
     ~VolumeResizer();
 
-    static const void scaleNearestNeighbor(VolumeData* const volume,
-                                           const VDTK::Vector3D<float>& scale,
-                                           const std::size_t numberOfThreads);
-    static const void scaleTrilinear(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
+    static void scaleNearestNeighbor(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
                                      const std::size_t numberOfThreads);
-    static const void scaleTricubic(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
-                                    const std::size_t numberOfThreads);
+    static void scaleTrilinear(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
+                               const std::size_t numberOfThreads);
+    static void scaleTricubic(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
+                              const std::size_t numberOfThreads);
 
 private:
     enum class InterpolationMode { Nearest, Trilinear, Tricubic };
 
-    static const void scaleSliceX(const VolumeData* const volume, VolumeData* volumeScaled,
-                                  const VDTK::Vector3D<float> scale,
-                                  const InterpolationMode interpolationMode,
-                                  const float scaledPositionX);
+    static void scaleSliceX(const VolumeData* const volume, VolumeData* volumeScaled,
+                            const VDTK::Vector3D<float> scale,
+                            const InterpolationMode interpolationMode, const float scaledPositionX);
 
-    static const void scaleVolume(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
-                                  const InterpolationMode interpolationMode,
-                                  const std::size_t numberOfThreads);
+    static void scaleVolume(VolumeData* const volume, const VDTK::Vector3D<float>& scale,
+                            const InterpolationMode interpolationMode,
+                            const std::size_t numberOfThreads);
 
     // Nearest neighbor interpolation
-    static const float getNearestNeigborValue(const VolumeData* const volume,
-                                              const VDTK::Vector3D<float>& originalPosition);
+    static float getNearestNeigborValue(const VolumeData* const volume,
+                                        const VDTK::Vector3D<float>& originalPosition);
 
     // Linear interpolation
-    static const inline float interpolateLinear(const std::array<float, 2>& values, const float x);
-    static const inline float interpolateBilinear(
-        const std::array<std::array<float, 2>, 2>& valuePlane, const float x, const float y);
-    static const inline float interpolateTrilinear(
+    static inline float interpolateLinear(const std::array<float, 2>& values, const float x);
+    static inline float interpolateBilinear(const std::array<std::array<float, 2>, 2>& valuePlane,
+                                            const float x, const float y);
+    static inline float interpolateTrilinear(
         const std::array<std::array<std::array<float, 2>, 2>, 2>& valueGrid, const float x,
         const float y, const float z);
-    static const float getTrilinearInterpolatedValue(const VolumeData* const volume,
-                                                     const VDTK::Vector3D<float>& originalSize,
-                                                     const VDTK::Vector3D<float>& originalPosition);
+    static float getTrilinearInterpolatedValue(const VolumeData* const volume,
+                                               const VDTK::Vector3D<float>& originalSize,
+                                               const VDTK::Vector3D<float>& originalPosition);
 
     // Cubic interpolation
-    static const inline float interpolateCubic(const std::array<float, 4>& values, const float x);
-    static const inline float interpolateBicubic(
-        const std::array<std::array<float, 4>, 4>& valuePlane, const float x, const float y);
-    static const inline float interpolateTricubic(
+    static inline float interpolateCubic(const std::array<float, 4>& values, const float x);
+    static inline float interpolateBicubic(const std::array<std::array<float, 4>, 4>& valuePlane,
+                                           const float x, const float y);
+    static inline float interpolateTricubic(
         const std::array<std::array<std::array<float, 4>, 4>, 4>& valueGrid, const float x,
         const float y, const float z);
-    static const float getTricubicInterpolatedValue(const VolumeData* const volume,
-                                                    const VDTK::Vector3D<float>& originalSize,
-                                                    const VDTK::Vector3D<float>& originalPosition);
+    static float getTricubicInterpolatedValue(const VolumeData* const volume,
+                                              const VDTK::Vector3D<float>& originalSize,
+                                              const VDTK::Vector3D<float>& originalPosition);
 };
 
 } // namespace VDTK

--- a/src/filter/WindowFilter.cpp
+++ b/src/filter/WindowFilter.cpp
@@ -8,9 +8,9 @@ WindowFilter::WindowFilter() {}
 
 WindowFilter::~WindowFilter() {}
 
-const void WindowFilter::applyWindow(VolumeData* const volume, const int32_t windowCenter,
-                                     const int32_t windowWidth, const int32_t windowOffset,
-                                     const std::size_t numberOfThreads) {
+void WindowFilter::applyWindow(VolumeData* const volume, const int32_t windowCenter,
+                               const int32_t windowWidth, const int32_t windowOffset,
+                               const std::size_t numberOfThreads) {
     {
         // create own scope to use destructor of thread pool (wait for all task to
         // finish)
@@ -25,9 +25,9 @@ const void WindowFilter::applyWindow(VolumeData* const volume, const int32_t win
     }
 }
 
-const void WindowFilter::applyWindowSliceX(VolumeData* const volume, const int32_t windowCenter,
-                                           const int32_t windowWidth, const int32_t windowOffset,
-                                           const std::size_t positionX) {
+void WindowFilter::applyWindowSliceX(VolumeData* const volume, const int32_t windowCenter,
+                                     const int32_t windowWidth, const int32_t windowOffset,
+                                     const std::size_t positionX) {
     double level = windowCenter;
     double width = windowWidth;
     double offset = windowOffset;

--- a/src/filter/WindowFilter.h
+++ b/src/filter/WindowFilter.h
@@ -7,14 +7,14 @@ public:
     WindowFilter();
     ~WindowFilter();
 
-    static const void applyWindow(VolumeData* const volume, const int32_t windowCenter,
-                                  const int32_t windowWidth, const int32_t windowOffset,
-                                  const std::size_t numberOfThreads);
+    static void applyWindow(VolumeData* const volume, const int32_t windowCenter,
+                            const int32_t windowWidth, const int32_t windowOffset,
+                            const std::size_t numberOfThreads);
 
 private:
-    static const void applyWindowSliceX(VolumeData* const volume, const int32_t windowCenter,
-                                        const int32_t windowWidth, const int32_t windowOffset,
-                                        const std::size_t positionX);
+    static void applyWindowSliceX(VolumeData* const volume, const int32_t windowCenter,
+                                  const int32_t windowWidth, const int32_t windowOffset,
+                                  const std::size_t positionX);
 };
 
 } // namespace VDTK

--- a/src/manipulation/EdgeCutter.cpp
+++ b/src/manipulation/EdgeCutter.cpp
@@ -6,7 +6,7 @@ EdgeCutter::EdgeCutter() {}
 
 EdgeCutter::~EdgeCutter() {}
 
-const void EdgeCutter::cutBorders(VolumeData* const volume, const uint16_t threshold) {
+void EdgeCutter::cutBorders(VolumeData* const volume, const uint16_t threshold) {
     std::size_t lowerBorderX = 0;
     std::size_t upperBorderX = 0;
     std::size_t lowerBorderY = 0;

--- a/src/manipulation/EdgeCutter.h
+++ b/src/manipulation/EdgeCutter.h
@@ -7,7 +7,7 @@ public:
     EdgeCutter();
     ~EdgeCutter();
 
-    static const void cutBorders(VolumeData* const volume, const uint16_t threshold = 0);
+    static void cutBorders(VolumeData* const volume, const uint16_t threshold = 0);
 
 private:
 };


### PR DESCRIPTION
The 'const' modifier has no effect on return types. The 'const' modifying the return type can be removed.